### PR TITLE
Make this package "Universal JS"-friendly

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "declaration": true,
-        "module": "esnext",
+        "module": "commonjs",
         "moduleResolution": "node",
         "noImplicitAny": true,
         "lib": ["esnext"],


### PR DESCRIPTION
Fixes the following error, which occurs when *apollo-link-debounce* is imported in Node:
```
.../node_modules/apollo-link-debounce/build/dist/index.js:1
(function (exports, require, module, __filename, __dirname) { import DebounceLink from './DebounceLink';
                                                              ^^^^^^

SyntaxError: Unexpected token import
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:599:28)
...
```