### PR TITLE
Bump apollo-link dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.3",
   "description": "An Apollo Link to debounce requests",
   "dependencies": {
-    "apollo-link": "^0.7.0"
+    "apollo-link": "^1.0.0"
   },
   "devDependencies": {
     "@types/graphql": "^0.11.7",


### PR DESCRIPTION
Having this old version constraint on apollo-link results in an extra (old) copy of apollo-link installed just for this package.