### PR TITLE
Allow integration with projects that don't use React

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "description": "An Apollo Link to debounce requests",
   "dependencies": {
     "apollo-link": "^1.2.2",
+    "lodash.merge": "^4.6.2",
     "zen-observable-ts": "^0.8.9"
   },
   "devDependencies": {
     "@types/graphql": "^0.13.0",
     "@types/jest": "^23.1.4",
+    "@types/lodash.merge": "^4.6.6",
     "@types/node": "10.1.2",
     "codecov": "^3.0.3",
     "graphql": "^0.13.2",

--- a/src/DebounceLink.test.ts
+++ b/src/DebounceLink.test.ts
@@ -10,7 +10,7 @@ import {
     execute,
     GraphQLRequest,
     ApolloLink,
-} from '@apollo/client';
+} from '@apollo/client/core';
 import {
     ExecutionResult,
 } from 'graphql';

--- a/src/DebounceLink.ts
+++ b/src/DebounceLink.ts
@@ -5,7 +5,7 @@ import {
     Observer,
     Operation,
     NextLink,
-} from '@apollo/client';
+} from '@apollo/client/core';
 
 interface OperationQueueEntry {
     operation: Operation;

--- a/src/TestUtils.ts
+++ b/src/TestUtils.ts
@@ -48,7 +48,7 @@ export class TestLink extends ApolloLink {
         this.operations = [];
     }
 
-    public request (operation: Operation) {
+    public request(operation: Operation) {
         this.operations.push(operation);
         // TODO(helfer): Throw an error if neither testError nor testResponse is defined
         return new Observable(observer => {
@@ -69,7 +69,7 @@ export class TestSequenceLink extends ApolloLink {
         this.operations = [];
     }
 
-    public request (operation: Operation, forward: NextLink) {
+    public request(operation: Operation, forward: NextLink) {
         if (!operation.getContext().testSequence) {
             return forward(operation);
         }

--- a/src/TestUtils.ts
+++ b/src/TestUtils.ts
@@ -3,7 +3,7 @@ import {
     Operation,
     Observable,
     NextLink,
-} from '@apollo/client';
+} from '@apollo/client/core';
 import {
     ExecutionResult,
 } from 'graphql';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,9 @@
         "module": "commonjs",
         "moduleResolution": "node",
         "noImplicitAny": true,
-        "lib": ["esnext"],
+        "lib": [
+            "esnext"
+        ],
         "removeComments": true,
         "preserveConstEnums": true,
         "outDir": "build/dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,6 +28,18 @@
   version "23.1.4"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.1.4.tgz#71e1e2d08b1db742f479ee2795536ebc999a2419"
 
+"@types/lodash.merge@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
+  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
 "@types/node@10.1.2":
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.1.2.tgz#1b928a0baa408fc8ae3ac012cc81375addc147c6"
@@ -4428,6 +4440,11 @@ lodash.isstring@^4.0.1:
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
This package indirectly imports React since it imports from the apollo client package:
```javascript
import {...} from "@apollo/client"
```
This package is dependent on React as it incudes the client and its React bindings. Since this package does not use any of the React specific functions this can be changed to:
```javascript
import {...} from "@apollo/client/core"
```
This removes the dependency for react and allows the integration with projects that don't use react. This change does not affect the functionality in React projects.